### PR TITLE
Fix for download URL: apache- prefix

### DIFF
--- a/groovy/spoon.me
+++ b/groovy/spoon.me
@@ -35,7 +35,7 @@ batch
 cmd python getTag.py
 var tag = last
 
-var url = "http://dl.bintray.com/groovy/maven/groovy-binary-" + tag + ".zip"
+var url = "http://dl.bintray.com/groovy/maven/apache-groovy-binary-" + tag + ".zip"
 
 cmd "wget --no-check-certificate -O groovy-binary.zip %url%"
 cmd 7z x groovy-binary.zip -oc:\Groovy


### PR DESCRIPTION
Apache took over groovy from version 2.4.4:
https://jaxenter.com/groovy-2-4-4-has-landed-under-the-apache-foundation-119018.html

Namespace remains unchanged: pivotal